### PR TITLE
add handling of new dynamic address registration errors in PAN-OS 6.0.

### DIFF
--- a/lib/pan/xapi.py
+++ b/lib/pan/xapi.py
@@ -335,6 +335,21 @@ class PanXapi:
                     elem = line.find('line')
                     if elem is not None and elem.text is not None:
                         lines.append(elem.text)
+                    # <line><uid-response><payload><register>
+                    #   <entry message="xxx"/>
+                    # </register></payload></uid-response></line>
+                    elem = line.find('uid-response')
+                    if elem is not None:
+                        paths = [
+                            'payload/register/entry',
+                            'payload/unregister/entry'
+                        ]
+                        for path in paths:
+                            for entry in elem.findall(path):
+                                lines.append("%s : %s" %
+                                             (entry.get('ip'),
+                                              entry.get('message'))
+                                             )
             return '\n'.join(lines) if lines else None
 
         path = './result/msg/line'


### PR DESCRIPTION
Hi Kevin,

I noticed that in PAN-OS 6.0, if you tag an IP with a tag it already has, it produces an error which is raised as a PanXapiError.  This is fine, but the error text is blank so it's impossible to tell this PanXapiError from another.  In my code, I needed to ignore this error because I don't care if the tag already existed, so I needed a way to distinguish this error from others.  The XML response for the error looks like this:

```
<response status="error">
    <msg>
        <line>
            <uid-response>
                <version>2.0</version>
                <payload>
                    <register>
                        <entry ip="192.168.1.2" message="tag your-tag already exists, ignore"/>
                        <entry ip="192.168.1.3" message="tag your-tag already exists, ignore"/>
                    </register>
                </payload>
            </uid-response>
        </line>
    </msg>
</response>
```

I added some code to the function that gets the return status in xapi so that it can handle this new `<uid-response>` tag to get the error message correctly.  It only handles register and unregister errors, but these are the only errors I've seen from the User-ID API that aren't handled.

Feel free to update or enhance my attempt as you see fit.  Thanks!
