### PR TITLE
Support commit targeted with serial number.

### DIFF
--- a/lib/pan/xapi.py
+++ b/lib/pan/xapi.py
@@ -741,6 +741,8 @@ class PanXapi:
         query = {}
         query['type'] = 'commit'
         query['key'] = self.api_key
+        if self.serial is not None:
+            query['target'] = self.serial
         if cmd is not None:
             query['cmd'] = cmd
         if action is not None:


### PR DESCRIPTION
Allows for using serial number to set a 'target' in the API call for a commit.  This means you can commit changes local to a device using Panorama as a proxy for the commit action.
