### PR TITLE
Add support for 'override' action.

### DIFF
--- a/bin/panxapi.py
+++ b/bin/panxapi.py
@@ -141,6 +141,13 @@ def main():
             print_status(xapi, action)
             print_response(xapi, options)
 
+        if options['override']:
+            action = 'override'
+            xapi.override(xpath=options['xpath'],
+                     element=options['element'])
+            print_status(xapi, action)
+            print_response(xapi, options)
+
         if options['export'] is not None:
             action = 'export'
             xapi.export(category=options['export'],
@@ -254,6 +261,7 @@ def parse_opts():
         'move': None,
         'rename': False,
         'clone': False,
+        'override': False,
         'api_username': None,
         'api_password': None,
         'hostname': None,
@@ -292,7 +300,7 @@ def parse_opts():
     long_options = ['version', 'help',
                     'ad-hoc=', 'modify', 'force', 'partial=', 'sync',
                     'vsys=', 'src=', 'dst=', 'move=', 'rename',
-                    'clone', 'export=', 'log=', 'recursive',
+                    'clone', 'override=', 'export=', 'log=', 'recursive',
                     'cafile=', 'capath=', 'ls', 'serial=',
                     'group=', 'merge', 'nlogs=', 'skip=', 'filter=',
                     'interval=', 'timeout=',
@@ -365,6 +373,8 @@ def parse_opts():
             options['rename'] = True
         elif opt == '--clone':
             options['clone'] = True
+        elif opt == '--override':
+            options['override'] = True
         elif opt == '-l':
             try:
                 (options['api_username'],
@@ -658,6 +668,7 @@ def usage():
     --move where          move after, before, bottom or top
     --rename              rename object at xpath to dst
     --clone               clone object at xpath, src xpath
+    --override element    override template object at xpath
     --vsys vsys           VSYS for dynamic update/partial commit/
                           operational command
     -l api_username:api_password

--- a/doc/pan.xapi.rst
+++ b/doc/pan.xapi.rst
@@ -272,6 +272,16 @@ clone(xpath=None, xpath_from=None, newname=None)
  by **xpath**.  **xpath_from** is used to specify the source XPath and
  **newname** is used to specify the new name for the cloned node.
 
+override(xpath=None, element=None)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ The override() method performs the ``action=override`` device
+ configuration API request with the **xpath** and **element**
+ arguments. override() is used to create a new object at a node
+ that is part of a template from Panorama specified by **xpath**.
+ Only certain nodes in the Network and Device categories can
+ be overridden.
+
 user_id(cmd=None, vsys=None)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/panxapi.rst
+++ b/doc/panxapi.rst
@@ -58,6 +58,7 @@ SYNOPSIS
     --move where          move after, before, bottom or top
     --rename              rename object at xpath to dst
     --clone               clone object at xpath, src xpath
+    --override element    override template object at xpath
     --vsys vsys           VSYS for dynamic update/partial commit/
                           operational command
     -l api_username:api_password
@@ -290,6 +291,16 @@ DESCRIPTION
   This clones (copies) an existing node in the configuration specified by
   **xpath**.  **--src** is used to specify the source XPath and **--dst**
   is used to specify the new name for the cloned node.
+
+ ``--override``
+  Perform the ``action=override`` device configuration API request with the
+  **element** and **xpath** arguments.  ``override`` is used to create a new
+  object at the node specified by **xpath** when the xpath is part of a
+  template applied by Panorama.  Only specific nodes in the Device and
+  Network categories can be overridden.
+
+  **element** can be an XML string, a path to a file containing XML,
+  or the value **-** to specify the XML is on *stdin*.
 
  ``--vsys`` *vsys*
   Specify optional **vsys** for dynamic update (**-U**), partial vsys

--- a/lib/pan/xapi.py
+++ b/lib/pan/xapi.py
@@ -679,6 +679,14 @@ class PanXapi:
             query['newname'] = newname
         self.__type_config('clone', query)
 
+    def override(self, xpath=None, element=None):
+        query = {}
+        if xpath is not None:
+            query['xpath'] = xpath
+        if element is not None:
+            query['element'] = element
+        self.__type_config('override', query)
+
     def __type_config(self, action, query):
         self.__set_api_key()
         self.__clear_response()


### PR DESCRIPTION
Override acts like set, but only works on specific template nodes.  So the override method mimics the behavior of the set method but with action=override.  When overriding a non-template node, or setting a template node, an error is produced by the firewall API which is raised as a PanXapiError.
