### PR TITLE
Support for using a proxy when connecting to Palo Alto Networks devices

### DIFF
--- a/bin/panwfapi.py
+++ b/bin/panwfapi.py
@@ -78,7 +78,8 @@ def main():
                                    hostname=options['hostname'],
                                    timeout=options['timeout'],
                                    http=options['http'],
-                                   ssl_context=ssl_context)
+                                   ssl_context=ssl_context,
+                                   proxy=options['proxy'])
 
     except pan.wfapi.PanWFapiError as msg:
         print('pan.wfapi.PanWFapi:', msg, file=sys.stderr)
@@ -359,6 +360,7 @@ def parse_opts():
         'debug': 0,
         'tag': None,
         'timeout': None,
+        'proxy': None,
         }
 
     short_options = 'K:h:xpjHDt:T:'
@@ -369,7 +371,7 @@ def parse_opts():
                     'hash=', 'platform=', 'testfile',
                     'new-verdict=', 'email=', 'comment=',
                     'format=', 'date=', 'dst=',
-                    'http', 'ssl=', 'cafile=', 'capath=',
+                    'http', 'ssl=', 'cafile=', 'capath=', 'proxy=',
                     ]
 
     try:
@@ -453,6 +455,8 @@ def parse_opts():
                 options['tag'] = arg
         elif opt == '-T':
             options['timeout'] = arg
+        elif opt == '--proxy':
+            options['proxy'] = arg
         elif opt == '--version':
             print('pan-python', pan.wfapi.__version__)
             sys.exit(0)
@@ -648,6 +652,7 @@ def usage():
     --ssl opt             SSL verify option: default|noverify|cacloud
     --cafile path         file containing CA certificates
     --capath path         directory of hashed certificate files
+    --proxy               proxy to use for http(s) requests
     --version             display version
     --help                display usage
 '''

--- a/bin/panxapi.py
+++ b/bin/panxapi.py
@@ -80,7 +80,8 @@ def main():
                                 hostname=options['hostname'],
                                 port=options['port'],
                                 serial=options['serial'],
-                                ssl_context=ssl_context)
+                                ssl_context=ssl_context,
+                                proxy=options['proxy'])
 
     except pan.xapi.PanXapiError as msg:
         print('pan.xapi.PanXapi:', msg, file=sys.stderr)
@@ -390,6 +391,7 @@ def parse_opts():
         'element': None,
         'cmd': None,
         'timeout': None,
+        'proxy': None,
         }
 
     valid_where = ['after', 'before', 'top', 'bottom']
@@ -402,7 +404,7 @@ def parse_opts():
                     'cafile=', 'capath=', 'ls', 'serial=',
                     'group=', 'merge', 'nlogs=', 'skip=', 'filter=',
                     'interval=', 'timeout=',
-                    'stime=', 'pcapid=', 'text',
+                    'stime=', 'pcapid=', 'text', 'proxy=',
                     ]
 
     try:
@@ -547,6 +549,8 @@ def parse_opts():
                 options['tag'] = arg
         elif opt == '-T':
             options['timeout'] = arg
+        elif opt == '--proxy':
+            options['proxy'] = arg
         elif opt == '--version':
             print('pan-python', pan.xapi.__version__)
             sys.exit(0)
@@ -872,6 +876,7 @@ def usage():
     -T seconds            urlopen() timeout
     --cafile path         file containing CA certificates
     --capath path         directory of hashed certificate files
+    --proxy               proxy to use for http(s) requests
     --version             display version
     --help                display usage
 '''

--- a/doc/pan.wfapi.rst
+++ b/doc/pan.wfapi.rst
@@ -106,7 +106,8 @@ class pan.wfapi.PanWFapi()
                            api_key=None,
                            timeout=None,
                            http=False,
-                           ssl_context=None)
+                           ssl_context=None,
+                           proxy=None)
 
  **tag**
   .panrc tagname.
@@ -140,6 +141,9 @@ class pan.wfapi.PanWFapi()
 
   SSL contexts are supported starting in Python versions 2.7.9
   and 3.2.
+
+ **proxy**
+  A proxy to use for HTTP(S) requests.
 
 exception pan.wfapi.PanWFapiError
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/pan.xapi.rst
+++ b/doc/pan.xapi.rst
@@ -97,7 +97,8 @@ class pan.xapi.PanXapi()
                          use_http=False,
                          use_get=False,
                          timeout=None,
-                         ssl_context=None)
+                         ssl_context=None,
+                         proxy=None)
 
  **tag**
   .panrc tagname.
@@ -163,6 +164,9 @@ class pan.xapi.PanXapi()
   Because many PAN-OS systems use a self-signed certificate, pan.xapi
   will disable the default starting with these versions.
   **ssl_context** can be used to enable verification.
+
+ **proxy**
+  A proxy to use for HTTP(S) requests.
 
 exception pan.xapi.PanXapiError
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/panrc.rst
+++ b/doc/panrc.rst
@@ -75,6 +75,12 @@ DESCRIPTION
   hostname%eng-fw=172.29.9.124
   api_key%eng-fw=C2M1P2h1tDEz8zF3SwhF2dWC1gzzhnE1qU39EmHtGZM=
 
+  # proxy
+  api_username=api
+  api_password=admin
+  hostname=192.168.1.1
+  proxy=http://user:pass@proxy.local:3128
+
  *tagname* must match the regular expression **/^[\w-]+$/** (1 or more
  alphanumeric characters plus "-" and "_").
 
@@ -92,6 +98,7 @@ Recognized varname Values
  **api_username**   X
  **api_password**   X
  **api_key**        X       X
+ **proxy**          X       X
  ================   ======  ========
 
 .panrc File Permissions

--- a/doc/panwfapi.rst
+++ b/doc/panwfapi.rst
@@ -61,6 +61,7 @@ SYNOPSIS
     --ssl opt             SSL verify option: default|noverify|cacloud
     --cafile path         file containing CA certificates
     --capath path         directory of hashed certificate files
+    --proxy               proxy to use for http(s) requests
     --version             display version
     --help                display usage
 
@@ -252,6 +253,9 @@ DESCRIPTION
  ``--capath`` *path*
   ``capath`` is a directory of hashed certificate files to be used for
    SSL server certificate verification.
+
+ ``--proxy`` *http://user:pass@proxy-hostname:port*
+  ``proxy`` is the proxy to use for HTTP(S) requests
 
  ``--version``
   Display version.

--- a/doc/panxapi.rst
+++ b/doc/panxapi.rst
@@ -93,6 +93,7 @@ SYNOPSIS
     -T seconds            urlopen() timeout
     --cafile path         file containing CA certificates
     --capath path         directory of hashed certificate files
+    --proxy               proxy to use for http(s) requests
     --version             display version
     --help                display usage
 
@@ -485,6 +486,9 @@ DESCRIPTION
   certificate verification. By default the SSL server certificate is
   not verified.  ``--cafile`` is supported starting in Python versions
   2.7.9 and 3.2.
+
+ ``--proxy`` *http://user:pass@proxy-hostname:port*
+  ``proxy`` is the proxy to use for HTTP(S) requests
 
  ``--version``
   Display version.

--- a/lib/pan/rc.py
+++ b/lib/pan/rc.py
@@ -32,6 +32,7 @@ _valid_varnames = set([
     'api_username',
     'api_password',
     'api_key',
+    'proxy',
     ])
 
 _indent = 2

--- a/lib/pan/wfapi.py
+++ b/lib/pan/wfapi.py
@@ -120,13 +120,15 @@ class PanWFapi:
                  api_key=None,
                  timeout=None,
                  http=False,
-                 ssl_context=None):
+                 ssl_context=None,
+                 proxy=None):
         self._log = logging.getLogger(__name__).log
         self.tag = tag
         self.hostname = hostname
         self.api_key = None
         self.timeout = timeout
         self.ssl_context = ssl_context
+        self.proxy = proxy
 
         self._log(DEBUG3, 'Python version: %s', sys.version)
         self._log(DEBUG3, 'xml.etree.ElementTree version: %s', etree.VERSION)
@@ -175,6 +177,16 @@ class PanWFapi:
 
         if _legacy_urllib:
             self._log(DEBUG2, 'using legacy urllib')
+
+        if proxy is not None:
+            self.proxy = proxy
+        elif 'proxy' in panrc.panrc:
+            self.proxy = panrc.panrc['proxy']
+
+        if self.proxy is not None:
+            # Set both http and https proxies
+            os.environ['http_proxy'] = self.proxy
+            os.environ['https_proxy'] = self.proxy
 
     def __str__(self):
         return '\n'.join((': '.join((k, str(self.__dict__[k]))))

--- a/lib/pan/xapi.py
+++ b/lib/pan/xapi.py
@@ -74,7 +74,8 @@ class PanXapi:
                  use_http=False,
                  use_get=False,
                  timeout=None,
-                 ssl_context=None):
+                 ssl_context=None,
+                 proxy=None):
         self._log = logging.getLogger(__name__).log
         self.tag = tag
         self.api_username = None
@@ -86,6 +87,7 @@ class PanXapi:
         self.use_get = use_get
         self.timeout = timeout
         self.ssl_context = ssl_context
+        self.proxy = proxy
 
         self._log(DEBUG3, 'Python version: %s', sys.version)
         self._log(DEBUG3, 'xml.etree.ElementTree version: %s', etree.VERSION)
@@ -183,6 +185,16 @@ class PanXapi:
 
         if _legacy_urllib:
             self._log(DEBUG2, 'using legacy urllib')
+
+        if proxy is not None:
+            self.proxy = proxy
+        elif 'proxy' in panrc.panrc:
+            self.proxy = panrc.panrc['proxy']
+
+        if self.proxy is not None:
+            # Set both http and https proxies
+            os.environ['http_proxy'] = self.proxy
+            os.environ['https_proxy'] = self.proxy
 
     def __str__(self):
         return '\n'.join((': '.join((k, str(self.__dict__[k]))))


### PR DESCRIPTION
Adding a --proxy= option to allow specifying a proxy to use when making requests to Palo Alto Networks devices.
