### PR TITLE
Support **kwargs for requests

### DIFF
--- a/lib/pan/http.py
+++ b/lib/pan/http.py
@@ -166,26 +166,12 @@ class PanHttp:
         self.content = response.read()
         self.text = self.content.decode(self.encoding)
 
-    def _http_request_requests(self, url, headers, data, params):
-        kwargs = {
-            'verify': self.verify_cert,
-        }
-        if url is not None:
-            kwargs['url'] = url
-        if headers is not None:
-            kwargs['headers'] = headers
-        if data is not None:
-            kwargs['data'] = data
-        if params is not None:
-            kwargs['params'] = params
-        if self.timeout is not None:
-            kwargs['timeout'] = self.timeout
-
+    def _http_request_requests(self, **kwargs):
         try:
-            if data is None:
-                r = requests.get(**kwargs)
-            else:
+            if kwargs.get('data'):
                 r = requests.post(**kwargs)
+            else:
+                r = requests.get(**kwargs)
         except requests.exceptions.RequestException as e:
             raise PanHttpError(str(e))
 


### PR DESCRIPTION
Allowing _http_request_request() to receive kwargs allows
the programmer to extend _http_request_requests() so that
all the arguments of python-requests' calls can be supported.
For example, we need to provide the cert argument.
Passing kwargs straight through simplifies the code,
checking is None for every parameter was unecessary.