### PR TITLE
Support for XML API pre-panos 4.1.0 

### DIFF
--- a/doc/pan.xapi.rst
+++ b/doc/pan.xapi.rst
@@ -97,7 +97,8 @@ class pan.xapi.PanXapi()
                          use_http=False,
                          use_get=False,
                          timeout=None,
-                         ssl_context=None)
+                         ssl_context=None,
+                         legacy_api=False)
 
  **tag**
   .panrc tagname.
@@ -163,6 +164,9 @@ class pan.xapi.PanXapi()
   Because many PAN-OS systems use a self-signed certificate, pan.xapi
   will disable the default starting with these versions.
   **ssl_context** can be used to enable verification.
+
+  **legacy_api**
+  Use legacy URI structure for API requests on PanOS versions prior to 4.1.0.
 
 exception pan.xapi.PanXapiError
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/pan.xapi.rst
+++ b/doc/pan.xapi.rst
@@ -97,8 +97,7 @@ class pan.xapi.PanXapi()
                          use_http=False,
                          use_get=False,
                          timeout=None,
-                         ssl_context=None,
-                         legacy_api=False)
+                         ssl_context=None)
 
  **tag**
   .panrc tagname.
@@ -164,9 +163,6 @@ class pan.xapi.PanXapi()
   Because many PAN-OS systems use a self-signed certificate, pan.xapi
   will disable the default starting with these versions.
   **ssl_context** can be used to enable verification.
-
-  **legacy_api**
-  Use legacy URI structure for API requests on PanOS versions prior to 4.1.0.
 
 exception pan.xapi.PanXapiError
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/pan/xapi.py
+++ b/lib/pan/xapi.py
@@ -74,7 +74,8 @@ class PanXapi:
                  use_http=False,
                  use_get=False,
                  timeout=None,
-                 ssl_context=None):
+                 ssl_context=None,
+                 legacy_api=False):
         self._log = logging.getLogger(__name__).log
         self.tag = tag
         self.api_username = None
@@ -179,7 +180,8 @@ class PanXapi:
         self.uri = '%s://%s' % (scheme, self.hostname)
         if self.port is not None:
             self.uri += ':%s' % self.port
-        self.uri += '/api/'
+        # legacy_api is used by panos < 4.1.0
+        self.uri += '/api/' if not legacy_api else '/esp/restapi.esp'
 
         if _legacy_urllib:
             self._log(DEBUG2, 'using legacy urllib')

--- a/lib/pan/xapi.py
+++ b/lib/pan/xapi.py
@@ -74,8 +74,7 @@ class PanXapi:
                  use_http=False,
                  use_get=False,
                  timeout=None,
-                 ssl_context=None,
-                 legacy_api=False):
+                 ssl_context=None):
         self._log = logging.getLogger(__name__).log
         self.tag = tag
         self.api_username = None
@@ -180,8 +179,7 @@ class PanXapi:
         self.uri = '%s://%s' % (scheme, self.hostname)
         if self.port is not None:
             self.uri += ':%s' % self.port
-        # legacy_api is used by panos < 4.1.0
-        self.uri += '/api/' if not legacy_api else '/esp/restapi.esp'
+        self.uri += '/api/'
 
         if _legacy_urllib:
             self._log(DEBUG2, 'using legacy urllib')


### PR DESCRIPTION
Adding a legacy_api flag to pan.xapi.PanXapi() to handle XML API usage on older devices, pre-panos 4.1.0.