### PR TITLE
Support for type report in xapi

### DIFF
--- a/doc/pan.xapi.rst
+++ b/doc/pan.xapi.rst
@@ -69,6 +69,7 @@ DESCRIPTION
  - export file: ``type=export``
  - dynamic object update: ``type=user-id``
  - log retrieval: ``type=log``
+ - report retrieval: ``type=log``
 
 pan.xapi Constants
 ------------------
@@ -452,6 +453,65 @@ log(self, log_type=None, nlogs=None, skip=None, filter=None, interval=None, time
  The XML API schedules a job to create the log data; the log() method
  will then periodically perform an API request to determine if the
  job ID returned in the initial request is complete and receive the log
+ data.  Additional arguments to control the polling include:
+
+ - **interval**
+
+  A floating point number specifying the query interval in seconds
+  between each non-finished job status response.
+
+  The default is 0.5 seconds.
+
+ - **timeout**
+
+  The maximum number of seconds to wait for the job to finish.
+
+  The default is to try forever (**timeout** is set to *None* or 0).
+
+report(self, reporttype=None, reportname=None, period=None, cmd=None, vsys=None, interval=None, timeout=None, extra_qs=None)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ The report() method performs the ``type=report`` retrieve report API request
+ with the **reporttype** argument.
+
+ **reporttype** specifies the type of report to retrieve and can be:
+
+ - dynamic
+ - predefined
+ - custom
+
+ Additional API request arguments include:
+
+ - **reportname**
+
+  Specify the name of the report to retrieve.
+
+ - **period**
+
+  Specify the predefined periods for dynamic type reports.
+
+ - last-60-seconds
+ - last-15-minutes
+ - last-hour
+ - last-12-hrs
+ - last-24-hrs
+ - last-calendar-day
+ - last-7-days
+ - last-7-calendar-days
+ - last-calendar-week
+ - last-30-days
+
+ - **cmd**
+
+  Specify the report XML configuration for on-the-fly report generation of custom type reports.
+  
+ - **vsys**
+
+  Specify a Virtual System to target for the report generation.
+
+ The XML API schedules a job to generate the report data; the report() method
+ will then periodically perform an API request to determine if the
+ job ID returned in the initial request is complete and receive the report
  data.  Additional arguments to control the polling include:
 
  - **interval**

--- a/doc/pan.xapi.rst
+++ b/doc/pan.xapi.rst
@@ -472,7 +472,7 @@ report(self, reporttype=None, reportname=None, vsys=None, interval=None, timeout
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
  The report() method performs the ``type=report`` retrieve report API request
- with the **reporttype** argument.  **vsys** can be used to target the
+ with the **reporttype** and **reportname** argument.  **vsys** can be used to target the
  report to a specific Virtual System.
 
  **reporttype** specifies the type of report to retrieve and can be:
@@ -481,12 +481,14 @@ report(self, reporttype=None, reportname=None, vsys=None, interval=None, timeout
  - predefined
  - custom
 
- Additional API request arguments include:
-
  - **reportname**
 
   Specify the name of the report to retrieve.
 
+ In some report requests, the XML API schedules a job to
+ generate the report data; the report() method will then periodically
+ perform an API request to determine if the job ID returned in the initial
+ request is complete and receive the report data. Additional arguments
  to control the polling include:
 
  - **interval**

--- a/doc/pan.xapi.rst
+++ b/doc/pan.xapi.rst
@@ -468,7 +468,7 @@ log(self, log_type=None, nlogs=None, skip=None, filter=None, interval=None, time
 
   The default is to try forever (**timeout** is set to *None* or 0).
 
-report(self, reporttype=None, reportname=None, period=None, cmd=None, vsys=None, interval=None, timeout=None, extra_qs=None)
+report(self, reporttype=None, reportname=None, period=None, topn=None, cmd=None, vsys=None, interval=None, timeout=None, extra_qs=None)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
  The report() method performs the ``type=report`` retrieve report API request
@@ -500,7 +500,13 @@ report(self, reporttype=None, reportname=None, period=None, cmd=None, vsys=None,
  - last-7-calendar-days
  - last-calendar-week
  - last-30-days
+ 
+  Specific start and end times are not supported.
+ 
+ - **topn**
 
+  Specify the maximum number of rows for dynamic type reports.
+ 
  - **cmd**
 
   Specify the report XML configuration for on-the-fly report generation of custom type reports.

--- a/doc/pan.xapi.rst
+++ b/doc/pan.xapi.rst
@@ -472,7 +472,7 @@ report(self, reporttype=None, reportname=None, vsys=None, interval=None, timeout
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
  The report() method performs the ``type=report`` retrieve report API request
- with the **reporttype** and **reportname** argument.  **vsys** can be used to target the
+ with the **reporttype** and **reportname** arguments.  **vsys** can be used to target the
  report to a specific Virtual System.
 
  **reporttype** specifies the type of report to retrieve and can be:
@@ -480,10 +480,6 @@ report(self, reporttype=None, reportname=None, vsys=None, interval=None, timeout
  - dynamic
  - predefined
  - custom
-
- - **reportname**
-
-  Specify the name of the report to retrieve.
 
  In some report requests, the XML API schedules a job to
  generate the report data; the report() method will then periodically

--- a/doc/pan.xapi.rst
+++ b/doc/pan.xapi.rst
@@ -69,7 +69,7 @@ DESCRIPTION
  - export file: ``type=export``
  - dynamic object update: ``type=user-id``
  - log retrieval: ``type=log``
- - report retrieval: ``type=log``
+ - report retrieval: ``type=report``
 
 pan.xapi Constants
 ------------------
@@ -341,8 +341,8 @@ op(cmd=None, vsys=None, cmd_xml=False)
  request with the **cmd** argument and optional **vsys** argument.
  **cmd** is an XML document which represents the command to be executed.
  Commands and command options are XML elements, and command arguments
- are XML data.  **vsys** can be to to target the command to a specific
- Virtual System.
+ are XML data.  **vsys** can be used to target the command to a specific
+ Virtual System. 
 
  When **cmd_xml** is *True* a CLI-style **cmd** argument is converted to
  XML.  This works by converting all unquoted arguments in **cmd** to
@@ -468,11 +468,12 @@ log(self, log_type=None, nlogs=None, skip=None, filter=None, interval=None, time
 
   The default is to try forever (**timeout** is set to *None* or 0).
 
-report(self, reporttype=None, reportname=None, period=None, topn=None, cmd=None, vsys=None, interval=None, timeout=None, extra_qs=None)
+report(self, reporttype=None, reportname=None, vsys=None, interval=None, timeout=None, extra_qs=None)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
  The report() method performs the ``type=report`` retrieve report API request
- with the **reporttype** argument.
+ with the **reporttype** argument.  **vsys** can be used to target the
+ report to a specific Virtual System.
 
  **reporttype** specifies the type of report to retrieve and can be:
 
@@ -486,39 +487,7 @@ report(self, reporttype=None, reportname=None, period=None, topn=None, cmd=None,
 
   Specify the name of the report to retrieve.
 
- - **period**
-
-  Specify the predefined periods for dynamic type reports.
-
- - last-60-seconds
- - last-15-minutes
- - last-hour
- - last-12-hrs
- - last-24-hrs
- - last-calendar-day
- - last-7-days
- - last-7-calendar-days
- - last-calendar-week
- - last-30-days
- 
-  Specific start and end times are not supported.
- 
- - **topn**
-
-  Specify the maximum number of rows for dynamic type reports.
- 
- - **cmd**
-
-  Specify the report XML configuration for on-the-fly report generation of custom type reports.
-  
- - **vsys**
-
-  Specify a Virtual System to target for the report generation.
-
- The XML API schedules a job to generate the report data; the report() method
- will then periodically perform an API request to determine if the
- job ID returned in the initial request is complete and receive the report
- data.  Additional arguments to control the polling include:
+ to control the polling include:
 
  - **interval**
 

--- a/lib/pan/xapi.py
+++ b/lib/pan/xapi.py
@@ -1025,7 +1025,7 @@ class PanXapi:
             self._log(DEBUG2, 'sleep %.2f seconds', interval)
             time.sleep(interval)
 
-    def report(self, reporttype=None, reportname=None, period=None, cmd=None, vsys=None,
+    def report(self, reporttype=None, reportname=None, period=None, topn=None, cmd=None, vsys=None,
             interval=None, timeout=None, extra_qs=None):
         self.__set_api_key()
         self.__clear_response()
@@ -1057,6 +1057,8 @@ class PanXapi:
             query['reportname'] = reportname
         if period is not None:
             query['period'] = period
+        if topn is not None:
+            query['topn'] = topn
         if cmd is not None:
             query['cmd'] = cmd
         if vsys is not None:

--- a/lib/pan/xapi.py
+++ b/lib/pan/xapi.py
@@ -1025,7 +1025,7 @@ class PanXapi:
             self._log(DEBUG2, 'sleep %.2f seconds', interval)
             time.sleep(interval)
 
-    def report(self, reporttype=None, reportname=None, period=None, topn=None, cmd=None, vsys=None,
+    def report(self, reporttype=None, reportname=None, vsys=None,
             interval=None, timeout=None, extra_qs=None):
         self.__set_api_key()
         self.__clear_response()
@@ -1055,12 +1055,6 @@ class PanXapi:
             query['reporttype'] = reporttype
         if reportname is not None:
             query['reportname'] = reportname
-        if period is not None:
-            query['period'] = period
-        if topn is not None:
-            query['topn'] = topn
-        if cmd is not None:
-            query['cmd'] = cmd
         if vsys is not None:
             query['vsys'] = vsys
         if extra_qs is not None:
@@ -1075,7 +1069,10 @@ class PanXapi:
 
         job = self.element_root.find('./result/job')
         if job is None:
-            raise PanXapiError('no job element in type=report response')
+          if self.element_root.tag == 'report':
+            return
+          else:
+            raise PanXapiError('no job or report element in type=report response')
 
         query = {}
         query['type'] = 'report'


### PR DESCRIPTION
Hello,

I am opening this to add report generation support with pan.xapi.  The implementation is very straight-forward.  Basically, it is a copy/paste of the existing log function, with updated arguments.  It supports most of the capabilities as documented in the XML API documentation.  It lacks support for starttime and endtime arguments for dynamic type reports.  Some arguments can only be used with specific report types, but the error handling should be caught by the API rather than the caller.  I tested against a Panorama version running 7.0.  I understand there are stated concerns for the log function as it seems to load the entire XML response into an ElementTree object.  Since the code is copied from the log function, I am guessing the report function would be subject to similar issues, although in all but the most rare exceptions, reports should be much less data intensive due to summarization of fields and reduced column scoping.

```
import pan.xapi
my_panorama_xapi = pan.xapi.PanXapi(tag='my-panorama')
my_panorama_xapi.report(reporttype='custom',reportname='my-report')
print(my_panorama_xapi.xml_result())
```