### PR TITLE
Remove version for Python 3.7.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ Patches and Suggestions
 - Jonathan Kaplan
 - Andrew Stanton
 - Darlene Wong
+- Michael Richardson

--- a/lib/pan/afapi/__init__.py
+++ b/lib/pan/afapi/__init__.py
@@ -26,8 +26,7 @@ DEFAULT_API_VERSION = 'v%d.%d' % _default_api_version
 
 
 class _ApiVersion(namedtuple('api_version',
-                             ['major', 'minor'],
-                             verbose=False)):
+                             ['major', 'minor'])):
     def __str__(self):
         return 'v%d.%d' % (self.major, self.minor)
 

--- a/lib/pan/licapi/__init__.py
+++ b/lib/pan/licapi/__init__.py
@@ -26,8 +26,7 @@ DEFAULT_API_VERSION = 'v%d' % _default_api_version
 
 
 class _ApiVersion(namedtuple('api_version',
-                             ['version'],
-                             verbose=False)):
+                             ['version'])):
     def __str__(self):
         return 'v%d' % (self.version)
 


### PR DESCRIPTION
I tried to use this library under Python 3.7, where verbose has been removed from namedtuple.  The Python documentation for 2.7 and 3 show that `verbose=False` is the default for all those versions, so the easiest fix seems to be to remove it.