### PR TITLE
licapi: ensure version header uses only major version

### DIFF
--- a/lib/pan/licapi/__init__.py
+++ b/lib/pan/licapi/__init__.py
@@ -31,8 +31,7 @@ class _ApiVersion(namedtuple('api_version',
         return 'v%d' % (self.version)
 
     def __int__(self):
-        # reserve lower 8 bits for 'future' use
-        return self.version << 8
+        return self.version
 
 
 class PanLicapiError(Exception):


### PR DESCRIPTION
Using ```version << 8``` here resulted in the HTTP request having
a header of:
```
version: 255
```
which is an invalid API version.  This apparently used to work without
error against the license API server but no longer does.  The requests
are now refused with a 404 for any request that includes an invalid API
version.

**BEFORE THIS CHANGE**
You can see version in the output with -D.  String form is "v1", int form (sent in the header) is 0x0100.
```
$ ./panlicapi.py -K ${API_KEY} --authcode ${AUTHCODE} --get -D
api_version: v1, 0x0100
panrc: { 'api_key': '******'}
https://api.paloaltonetworks.com/api/license/get
{'authcode': '***'}
Starting new HTTPS connection (1): api.paloaltonetworks.com:443
https://api.paloaltonetworks.com:443 "POST /api/license/get HTTP/1.1" 404 120
get() wall time 0.38 seconds
get: 404 Not Found 120 0.38secs "No HTTP resource was found that matches the request URI 'http://api.paloaltonetworks.com/api/license/get'."

```
**AFTER THIS CHANGE**
The int form is now 0x0001 which is the correct value for the version header.
```
$ ./panlicapi.py -K ${API_KEY} --authcode ${AUTHCODE} --get -D
api_version: v1, 0x0001
panrc: { 'api_key': '******'}
https://api.paloaltonetworks.com/api/license/get
{'authcode': '***'}
Starting new HTTPS connection (1): api.paloaltonetworks.com:443
https://api.paloaltonetworks.com:443 "POST /api/license/get HTTP/1.1" 200 301
get() wall time 0.45 seconds
get: 200 OK 301 0.45secs
```
