### PR TITLE
Fix credential exposure in keygen() tracebacks

### DIFF
--- a/lib/pan/xapi.py
+++ b/lib/pan/xapi.py
@@ -605,24 +605,23 @@ class PanXapi:
 
         try:
             response = self.__api_request(query)
-            if not response:
-                raise PanXapiError(self.status_detail)
-
-            if not self.__set_response(response):
-                raise PanXapiError(self.status_detail)
-
-            if self.element_result is None:
-                raise PanXapiError('keygen(): result element not found')
-            element = self.element_result.find('key')
-            if element is None:
-                raise PanXapiError('keygen(): key element not found')
-
-            self.api_key = element.text
-
-            return self.api_key
         finally:
-            if isinstance(query, dict) and 'password' in query:
-                del query['password']
+            query.pop('password', None)
+        if not response:
+            raise PanXapiError(self.status_detail)
+
+        if not self.__set_response(response):
+            raise PanXapiError(self.status_detail)
+
+        if self.element_result is None:
+            raise PanXapiError('keygen(): result element not found')
+        element = self.element_result.find('key')
+        if element is None:
+            raise PanXapiError('keygen(): key element not found')
+
+        self.api_key = element.text
+
+        return self.api_key
 
     @staticmethod
     def __qs_to_dict(qs):

--- a/lib/pan/xapi.py
+++ b/lib/pan/xapi.py
@@ -603,22 +603,26 @@ class PanXapi:
         if extra_qs is not None:
             query = self.__merge_extra_qs(query, extra_qs)
 
-        response = self.__api_request(query)
-        if not response:
-            raise PanXapiError(self.status_detail)
+        try:
+            response = self.__api_request(query)
+            if not response:
+                raise PanXapiError(self.status_detail)
 
-        if not self.__set_response(response):
-            raise PanXapiError(self.status_detail)
+            if not self.__set_response(response):
+                raise PanXapiError(self.status_detail)
 
-        if self.element_result is None:
-            raise PanXapiError('keygen(): result element not found')
-        element = self.element_result.find('key')
-        if element is None:
-            raise PanXapiError('keygen(): key element not found')
+            if self.element_result is None:
+                raise PanXapiError('keygen(): result element not found')
+            element = self.element_result.find('key')
+            if element is None:
+                raise PanXapiError('keygen(): key element not found')
 
-        self.api_key = element.text
+            self.api_key = element.text
 
-        return self.api_key
+            return self.api_key
+        finally:
+            if isinstance(query, dict) and 'password' in query:
+                del query['password']
 
     @staticmethod
     def __qs_to_dict(qs):


### PR DESCRIPTION
## Summary
Prevent API passwords from being exposed in exception tracebacks when `keygen()` fails.

## Problem
The `keygen` method builds a `query` dict containing the password (`{'type': 'keygen', 'user': '...', 'password': '...'}`). On `PanXapiError`, the traceback can include this local variable, exposing credentials in logs and error reports.

## Solution
Clear the password from the `query` dict in a `try`/`finally` block so it is removed before any exception propagates. By the time the traceback is captured, the password is no longer in the query dict.

## Impact
- No change to API behavior; the password is only removed after the request is sent.
- `query` is used only by `__api_request`; no other references are affected.